### PR TITLE
Bootstrap Grid Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Use the `renderStart`, `renderEnd` and `renderField` methods for more fine-grain
 </div>
 ```
 
+By default, `renderEnd` will render all remaining un-rendered fields before rendering the closing </form> tag. To prevent this, pass `false` as the first argument:
+
+```php
+<?= $form->renderEnd(false); ?>
+```
+
 ## Collections
 
 The `CollectionType` can be used to add/remove multiple entries of the same field or set of fields:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,25 @@ if ($form->isSubmitted() && $form->isValid()) {
 
 See the [examples](examples) directory for examples using AJAX, file uploads, collections and more.
 
+## Rendering Individual Fields
+
+Use the `renderStart`, `renderEnd` and `renderField` methods for more fine-grained control over how fields are rendered, such as using Bootstrap's grid system:
+
+```php
+<div class="container">
+    <?= $form->renderStart(); ?>
+    <div class="row">
+        <div class="col-6">
+            <?= $form->renderField('first_name'); ?>
+        </div>
+        <div class="col-6">
+            <?= $form->renderField('last_name'); ?>
+        </div>
+    </div>
+    <?= $form->renderEnd(); ?>
+</div>
+```
+
 ## Collections
 
 The `CollectionType` can be used to add/remove multiple entries of the same field or set of fields:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.1",
         "palmtree/argparser": "^2.1",
         "palmtree/nameconverter": "^2.0",
-        "palmtree/html": "^4.0.1"
+        "palmtree/html": "^4.0.2"
     },
     "require-dev": {
         "palmtree/php-cs-fixer-config": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52e7dd3094ebba34f071b4c8f89705e0",
+    "content-hash": "b0839bfc05783a06ad100436f44cea46",
     "packages": [
         {
             "name": "palmtree/argparser",
@@ -52,16 +52,16 @@
         },
         {
             "name": "palmtree/html",
-            "version": "v4.0.1",
+            "version": "v4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/palmtreephp/html.git",
-                "reference": "4adecc1e56f1c7395440d301fa0c320c4c28d41a"
+                "reference": "f308352f4e227d01b6e142aa38ed9ae17ce5db07"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/palmtreephp/html/zipball/4adecc1e56f1c7395440d301fa0c320c4c28d41a",
-                "reference": "4adecc1e56f1c7395440d301fa0c320c4c28d41a",
+                "url": "https://api.github.com/repos/palmtreephp/html/zipball/f308352f4e227d01b6e142aa38ed9ae17ce5db07",
+                "reference": "f308352f4e227d01b6e142aa38ed9ae17ce5db07",
                 "shasum": ""
             },
             "require": {
@@ -92,9 +92,9 @@
             "description": "HTML component for Palmtree PHP",
             "support": {
                 "issues": "https://github.com/palmtreephp/html/issues",
-                "source": "https://github.com/palmtreephp/html/tree/v4.0.1"
+                "source": "https://github.com/palmtreephp/html/tree/v4.0.2"
             },
-            "time": "2022-01-16T13:32:32+00:00"
+            "time": "2022-07-12T11:41:05+00:00"
         },
         {
             "name": "palmtree/nameconverter",
@@ -3177,5 +3177,5 @@
         "php": ">=7.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/examples/grid/index.php
+++ b/examples/grid/index.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Palmtree\Form\FormBuilder;
+use Palmtree\Form\Type\EmailType;
+use Palmtree\Form\Type\TelType;
+use Palmtree\Form\Type\TextareaType;
+use Palmtree\Form\Type\TextType;
+
+require __DIR__ . '/../../vendor/autoload.php';
+require __DIR__ . '/../.bootstrap.php';
+
+$builder = (new FormBuilder('grid_example'))
+    ->add('first_name', TextType::class, [
+    ])
+    ->add('last_name', TextType::class, [
+    ])
+    ->add('email_address', EmailType::class, [
+    ])
+    ->add('telephone_number', TelType::class, [
+    ])
+    ->add('address', TextareaType::class, [
+    ])
+;
+
+$builder->add('Submit', 'submit');
+
+$form = $builder->getForm();
+
+$form->handleRequest();
+
+if ($form->isSubmitted() && $form->isValid()) {
+    redirect('?success=1');
+}
+
+$view = template('view.phtml', [
+    'form' => $form,
+    'success' => !empty($_GET['success']),
+]);
+
+echo $view;

--- a/examples/grid/view.phtml
+++ b/examples/grid/view.phtml
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Palmtree Form - Simple Example</title>
+    <?= get_styles(); ?>
+</head>
+<body>
+<main>
+    <div class="container mt-3">
+        <h1>Palmtree Form - Bootstrap Grid Example</h1>
+        <?php if ($success): ?>
+            <div class="alert alert-success">Form submitted successfully</div>
+        <?php endif; ?>
+        <?= $form->renderStart(); ?>
+        <div class="row">
+            <div class="col-6">
+                <?= $form->renderField('first_name'); ?>
+            </div>
+            <div class="col-6">
+                <?= $form->renderField('last_name'); ?>
+            </div>
+        </div>
+        <?= $form->renderEnd(); ?>
+    </div>
+</main>
+<?= get_scripts(); ?>
+</body>
+</html>

--- a/src/FormRenderer.php
+++ b/src/FormRenderer.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Palmtree\Form;
+
+use Palmtree\Form\Exception\OutOfBoundsException;
+use Palmtree\Form\Type\CheckboxType;
+use Palmtree\Form\Type\HiddenType;
+use Palmtree\Html\Element;
+
+class FormRenderer
+{
+    /** @var Element */
+    private $element;
+    /** @var Form */
+    private $form;
+    /** @var array<string, list<Element>> */
+    private $fields = [];
+    /** @var list<string> */
+    private $renderedFields = [];
+    /** @var bool */
+    private $built = false;
+
+    public function __construct(Form $form)
+    {
+        $this->form = $form;
+        $this->element = new Element('form.palmtree-form');
+    }
+
+    public function renderStart(): string
+    {
+        $this->buildElement();
+
+        return $this->element->renderStart();
+    }
+
+    public function render(): string
+    {
+        $this->buildElement();
+
+        return $this->element->render();
+    }
+
+    public function renderEnd(bool $renderRest = true): string
+    {
+        $this->buildElement();
+
+        $html = '';
+
+        if ($renderRest) {
+            foreach ($this->fields as $name => $field) {
+                if (!\in_array($name, $this->renderedFields)) {
+                    $html .= $this->renderField($name);
+                }
+            }
+        }
+
+        $html .= $this->element->renderEnd();
+
+        return $html;
+    }
+
+    public function renderField(string $name): string
+    {
+        $this->buildElement();
+
+        if (!isset($this->fields[$name])) {
+            throw new OutOfBoundsException("Field with key '$name' does not exist");
+        }
+
+        $html = '';
+        foreach ($this->fields[$name] as $field) {
+            $html .= $field->render();
+        }
+
+        $this->renderedFields[] = $name;
+
+        return $html;
+    }
+
+    private function buildElement(): void
+    {
+        if ($this->built) {
+            return;
+        }
+
+        $this->element->attributes->add([
+            'method' => $this->form->getMethod(),
+            'id' => $this->form->getKey(),
+        ]);
+
+        if ($this->form->getEncType() !== null) {
+            $this->element->attributes->set('enctype', $this->form->getEncType());
+        }
+
+        if ($this->form->getAction() !== null) {
+            $this->element->attributes->set('action', $this->form->getAction());
+        }
+
+        if (!$this->form->hasHtmlValidation()) {
+            $this->element->attributes->set('novalidate');
+        }
+
+        if ($this->form->isAjax()) {
+            $this->element->classes[] = 'is-ajax';
+        }
+
+        if ($this->form->isSubmitted()) {
+            $this->element->classes[] = 'is-submitted';
+        }
+
+        $this->element->attributes->setData('invalid_element', htmlentities($this->form->createInvalidElement()->render()));
+
+        $this->addFieldsToElement();
+
+        $this->built = true;
+    }
+
+    private function addFieldsToElement(): void
+    {
+        foreach ($this->form->getFields() as $field) {
+            $fieldWrapper = null;
+            $parent = $this->element;
+
+            if ($this->form->getFieldWrapper() && !$field instanceof HiddenType) {
+                $fieldWrapper = new Element($this->form->getFieldWrapper());
+
+                if ($field->isRequired()) {
+                    $fieldWrapper->classes[] = 'is-required';
+                }
+
+                $parent = $fieldWrapper;
+            }
+
+            if ($field instanceof CheckboxType) {
+                $parent->classes[] = 'form-check';
+            }
+
+            foreach ($field->getElements() as $element) {
+                $parent->addChild($element);
+
+                if (!$fieldWrapper instanceof Element) {
+                    $this->fields[$field->getName()][] = $element;
+                }
+            }
+
+            if ($fieldWrapper instanceof Element) {
+                $this->element->addChild($fieldWrapper);
+                $this->fields[$field->getName()] = [$fieldWrapper];
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds renderStart, renderField and renderEnd methods to developers can choose to wrap their fields in Bootstrap grid column classes - or anything else they want to.

A usage example is provided in `examples/grid`, but the gist is:

```php
<?= $form->renderStart(); ?>
<div class="row">
    <div class="col-6">
        <?= $form->renderField('first_name'); ?>
    </div>
    <div class="col-6">
        <?= $form->renderField('last_name'); ?>
    </div>
</div>
<?= $form->renderEnd(); ?>
```

Resolves #3