### PR TITLE
Implement CSRF protection

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,10 @@ jobs:
     strategy:
       matrix:
         php-versions: [ '8.3', '8.4', '8.5' ]
+        symfony-versions: [ '6.4', '7.4', '8.0' ]
+        exclude:
+          - php-versions: '8.3'
+            symfony-versions: '8.0'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,44 +35,48 @@ jobs:
 
       - name: Cache composer
         uses: actions/cache@v4
-        if: matrix.php-versions == 8.3
         with:
           path: ${{ steps.vars.outputs.composer_cache_dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
 
+      - name: Install Symfony Flex
+        run: |
+          composer global config --no-plugins allow-plugins.symfony/flex true
+          composer global require symfony/flex
+
+      - name: Configure Symfony version for symfony/flex
+        run: composer config extra.symfony.require "${{ matrix.symfony-versions }}.*"
+
       - name: Install dependencies
-        run: composer install --no-interaction
-        if: matrix.php-versions == 8.3
+        run: composer update --no-interaction
 
       - name: Validate coding standards
+        if: matrix.php-versions == '8.3' && matrix.symfony-versions == '6.4'
         run: php vendor/bin/php-cs-fixer fix -vvv --dry-run --using-cache=no --format=checkstyle | cs2pr
-        if: matrix.php-versions == 8.3
 
       - name: Static Analysis
         run: php vendor/bin/phpstan analyse --error-format=github
-        if: matrix.php-versions == 8.3
 
       - name: Tests
         run: php vendor/bin/phpunit --do-not-cache-result
-        if: matrix.php-versions == 8.3
 
       - name: Setup Node
         uses: actions/setup-node@v4
-        if: matrix.php-versions == 8.3
+        if: matrix.php-versions == '8.3' && matrix.symfony-versions == '6.4'
         with:
           node-version: '20.x'
           cache: 'npm'
 
       - name: Install npm dependencies
-        if: matrix.php-versions == 8.3
+        if: matrix.php-versions == '8.3' && matrix.symfony-versions == '6.4'
         run: npm ci
 
       - name: Prettier
-        if: matrix.php-versions == 8.3
+        if: matrix.php-versions == '8.3' && matrix.symfony-versions == '6.4'
         run: npm run prettier:check
 
       - name: Typescript
-        if: matrix.php-versions == 8.3
+        if: matrix.php-versions == '8.3' && matrix.symfony-versions == '6.4'
         run: npm run type-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v6.4.0 - 2025-12-31
+
+* Added support for modern CSRF protection using same-origin validation. See the [CSRF protection docs](/docs/csrf-protection.md) for more info.
+
 ## v6.3.0 - 2025-12-02
 
 * Added ability to pass a NameConverter to the FormBuilder to customize how default labels and placeholders are generated from field names e.g. camelCase to Title Case.

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "php": ">=8.3",
         "palmtree/argparser": "^3.0",
         "palmtree/nameconverter": "^3.0",
-        "palmtree/html": "^5.0"
+        "palmtree/html": "^5.0",
+        "symfony/http-foundation": "^6.4||^7.4||^8.0"
     },
     "require-dev": {
         "palmtree/php-cs-fixer-config": "^2.0",
@@ -49,10 +50,5 @@
         "sa": "@php vendor/bin/phpstan analyse",
         "fix": "@php vendor/bin/php-cs-fixer fix",
         "test": "@php vendor/bin/phpunit"
-    },
-    "config": {
-        "platform": {
-            "php": "8.3"
-        }
     }
 }

--- a/docs/csrf-protection.md
+++ b/docs/csrf-protection.md
@@ -1,0 +1,138 @@
+# CSRF Protection
+
+Cross-Site Request Forgery (CSRF) protection is a security measure for preventing unauthorized form submissions from third-party sites.
+This library provides built-in CSRF protection using a same-origin verification strategy.
+
+## Overview
+
+The library protects against CSRF attacks by validating that form submissions originate from the same site that served the form.
+This is accomplished by checking HTTP headers that modern browsers send with requests:
+
+- **Sec-Fetch-Site**: The preferred modern header that explicitly indicates whether the request originated from the same site, a cross-site request, or other origins
+- **Origin** / **Referer**: Headers used as fallback methods to verify the request's source
+
+## Enabling CSRF Protection
+
+To enable CSRF protection for your form, call the `enableCsrf()` method on your `FormBuilder`:
+
+```php
+<?php
+
+use Palmtree\Form\FormBuilder;
+use Palmtree\Form\Type\TextType;
+
+// Optional but recommended: Configure trusted hosts
+// See https://symfony.com/doc/current/reference/configuration/framework.html#trusted-hosts
+\Symfony\Component\HttpFoundation\Request::setTrustedHosts(['^example\.org$']);
+
+$builder = new FormBuilder([
+    'key'    => 'contact_form',
+    'method' => 'POST',
+]);
+
+// Enable CSRF protection with default settings (strict mode enabled)
+$builder->enableCsrf();
+
+$builder
+    ->add('name', TextType::class, ['label' => 'Name'])
+    ->add('email', 'email', ['label' => 'Email'])
+    ->add('message', 'textarea', ['label' => 'Message'])
+    ->add('submit', 'submit');
+
+$form = $builder->getForm();
+```
+
+> [!NOTE]
+> If your site is behind a load balancer or reverse proxy, you may also need to call [`Request::setTrustedProxies()`](https://symfony.com/doc/current/deployment/proxies.html#solution-settrustedproxies) to ensure correct handling of headers.
+
+### Method Signature
+
+```php
+public function enableCsrf(bool $strict = true, ?Request $request = null): self
+```
+
+**Parameters:**
+- `$strict` (bool, default: `true`): When `true`, the validator requires explicit origin validation. A missing origin header in non-modern browsers will be treated as invalid in strict mode. When `false`, missing headers are tolerated.
+- `$request` (Request|null, default: `null`): An optional Symfony HttpFoundation `Request` object. If not provided, one is automatically created from superglobals.
+
+### Strict Mode
+
+By default, CSRF protection runs in strict mode. This means:
+
+- **Strict mode enabled** (`true`): All requests must have verifiable origin information. If the browser doesn't send origin headers, the request is rejected.
+- **Strict mode disabled** (`false`): The validator will accept requests even if no origin headers are present, falling back to assuming they are safe.
+
+For most modern web applications, strict mode is recommended as it provides the strongest protection. You might disable strict mode only if you need to support very old browsers or legacy clients that don't send origin headers.
+
+```php
+// Permissive mode (less secure, for legacy support)
+$builder->enableCsrf(strict: false);
+```
+
+### Validation Logic
+
+The `SameOriginCsrfValidator` checks origins in the following order:
+
+```
+1. If Sec-Fetch-Site header exists:
+   └─ Accept if value is 'same-origin'
+
+2. If Sec-Fetch-Site is absent:
+   ├─ Check Origin header
+   ├─ Check Referer header
+   └─ Compare against request's scheme and host
+      ├─ Accept if header matches (same-origin request)
+      ├─ Reject if header indicates different origin
+      └─ In strict mode: Reject if no headers present
+                In permissive mode: Accept if no headers present
+```
+
+## Custom CSRF Validators
+
+If you need custom CSRF validation logic, you can implement the `CsrfValidatorInterface` and set it on the form:
+
+```php
+<?php
+
+use Palmtree\Form\Csrf\CsrfValidatorInterface;
+use Palmtree\Form\Exception\CsrfValidationFailedException;
+
+class CustomCsrfValidator implements CsrfValidatorInterface
+{
+    public function validate(): void
+    {
+        // Your custom validation logic here
+        if (!$this->isValidToken()) {
+            throw new CsrfValidationFailedException('Custom CSRF validation failed');
+        }
+    }
+
+    private function isValidToken(): bool
+    {
+        // Implement your validation logic
+        return true;
+    }
+}
+
+// Use the custom validator
+$builder = new FormBuilder(['key' => 'my_form']);
+$builder->setCsrfValidator(new CustomCsrfValidator());
+```
+
+## Important Security Notes
+
+1. **HTTPS Recommended**: While same-origin validation works with HTTP, using HTTPS is strongly recommended to prevent header manipulation and other attacks.
+
+2. **Browser Support**: The `Sec-Fetch-Site` header is supported in all modern browsers. Older browsers may not send this header, which is why the validator has fallback logic for `Origin` and `Referer` headers.
+
+3. **Trusted Hosts**: When using Symfony's Request class, ensure you configure trusted hosts appropriately to prevent Host Header injection attacks:
+   ```php
+   \Symfony\Component\HttpFoundation\Request::setTrustedHosts(['localhost', 'example.com']);
+   ```
+
+4. **Safe Methods**: The validator automatically skips validation for safe HTTP methods (GET, HEAD, OPTIONS, TRACE). CSRF protection is only applied to state-changing requests (POST, PUT, PATCH, DELETE).
+
+## Further Reading
+
+- [Protecting Against CSRF in 2025](https://words.filippo.io/csrf/#protecting-against-csrf-in-2025)
+- [MDN Web Docs: Cross-Site Request Forgery (CSRF)](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/CSRF)

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@
 * [Ajax Submissions](ajax.md)
 * [Collections](collections.md)
 * [Constraints (Validation)](constraints.md)
+* [CSRF Protection](csrf-protection.md)
 * [Data Binding](data-binding.md)
 * [File Uploads](file-uploads.md)
 * [Name Converters](name-converters.md)

--- a/examples/csrf/index.php
+++ b/examples/csrf/index.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+use Palmtree\Form\FormBuilder;
+use Palmtree\Form\Type\TextType;
+
+require __DIR__ . '/../../vendor/autoload.php';
+require __DIR__ . '/../.bootstrap.php';
+
+\Symfony\Component\HttpFoundation\Request::setTrustedHosts(['localhost']);
+
+$builder = new FormBuilder([
+    'key'             => 'simple_example',
+    'method'          => 'POST',
+    'html_validation' => false,
+]);
+
+$builder->enableCsrf();
+
+$builder
+    ->add('name', TextType::class, [
+        'label' => 'Please enter your name',
+    ])
+    ->add('email_address', 'email', [
+        'help' => 'We will never share your email address with anyone.'
+    ]);
+
+$builder->add('send_message', 'submit');
+
+$form = $builder->getForm();
+
+$form->handleRequest();
+
+if ($form->isSubmitted() && $form->isValid()) {
+    redirect('?success=1');
+}
+
+$view = template('view.phtml', [
+    'form'    => $form,
+    'success' => !empty($_GET['success']),
+]);
+
+echo $view;

--- a/examples/csrf/view.phtml
+++ b/examples/csrf/view.phtml
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Palmtree Form - Simple Example</title>
+    <?= get_styles(); ?>
+</head>
+<body>
+<main>
+    <div class="container mt-3">
+        <h1>Palmtree Form - Simple Example</h1>
+        <?php if ($success): ?>
+            <div class="alert alert-success">Form submitted successfully</div>
+        <?php endif; ?>
+        <?= $form->render(); ?>
+    </div>
+</main>
+<?= get_scripts(); ?>
+<script src="/dist/palmtree-form.pkgd.js"></script>
+</body>
+</html>

--- a/examples/serve.sh
+++ b/examples/serve.sh
@@ -6,4 +6,4 @@ docker run --rm \
   -v "$PWD"/:/app -v "$PWD/dist":/app/examples/dist \
   -p "$port":"$port" \
   xisgo/php-cli-xdebug:8.3 \
-  php -c /app/examples/php.ini -S "0.0.0.0:$port" -t /app/examples 2>&1 | sed 's/0.0.0.0/127.0.0.1/'
+  php -c /app/examples/php.ini -S "0.0.0.0:$port" -t /app/examples 2>&1 | sed 's/0.0.0.0/localhost/'

--- a/src/Csrf/CsrfValidatorInterface.php
+++ b/src/Csrf/CsrfValidatorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Palmtree\Form\Csrf;
+
+interface CsrfValidatorInterface
+{
+    public function validate(): void;
+}

--- a/src/Csrf/SameOriginCsrfValidator.php
+++ b/src/Csrf/SameOriginCsrfValidator.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Palmtree\Form\Csrf;
+
+use Palmtree\Form\Exception\CsrfValidationFailedException;
+use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
+use Symfony\Component\HttpFoundation\Request;
+
+class SameOriginCsrfValidator implements CsrfValidatorInterface
+{
+    private Request $request;
+
+    public function __construct(
+        ?Request $request = null,
+        private readonly bool $strict = true,
+    ) {
+        $this->request = $request ?? Request::createFromGlobals();
+    }
+
+    /**
+     * Validate CSRF by checking Origin and Referer headers.
+     *
+     * @throws CsrfValidationFailedException
+     */
+    public function validate(): void
+    {
+        if ($this->request->isMethodSafe()) {
+            // Safe methods do not require CSRF validation
+            return;
+        }
+
+        try {
+            $isValidOrigin = $this->isValidOrigin();
+
+            if ($isValidOrigin === false || ($this->strict && $isValidOrigin === null)) {
+                throw new CsrfValidationFailedException('CSRF validation failed: invalid origin.');
+            }
+        } catch (SuspiciousOperationException $e) {
+            throw new CsrfValidationFailedException('CSRF validation failed: ' . $e->getMessage(), previous: $e);
+        }
+    }
+
+    public function isValidOrigin(): ?bool
+    {
+        if ($this->request->headers->has('Sec-Fetch-Site')) {
+            return $this->request->headers->get('Sec-Fetch-Site') === 'same-origin';
+        }
+
+        $target = $this->request->getSchemeAndHttpHost() . '/';
+        $source = 'null';
+
+        foreach (['Origin', 'Referer'] as $header) {
+            if (!$this->request->headers->has($header)) {
+                continue;
+            }
+
+            $source = $this->request->headers->get($header);
+
+            if (str_starts_with($source . '/', $target)) {
+                return true;
+            }
+        }
+
+        return $source === 'null' ? null : false;
+    }
+}

--- a/src/Exception/CsrfValidationFailedException.php
+++ b/src/Exception/CsrfValidationFailedException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Palmtree\Form\Exception;
+
+class CsrfValidationFailedException extends \RuntimeException
+{
+}

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Palmtree\Form;
 
+use Palmtree\Form\Csrf\CsrfValidatorInterface;
+use Palmtree\Form\Csrf\SameOriginCsrfValidator;
 use Palmtree\Form\DataMapper\DataMapperInterface;
 use Palmtree\Form\Type\CollectionType;
 use Palmtree\Form\Type\FileType;
@@ -11,6 +13,7 @@ use Palmtree\Form\Type\RepeatedType;
 use Palmtree\Form\Type\TextType;
 use Palmtree\Form\Type\TypeInterface;
 use Palmtree\NameConverter\NameConverterInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @phpstan-import-type TypeType from TypeLocator
@@ -135,5 +138,20 @@ class FormBuilder
 
             $this->recursiveEncTypeCheck($fieldType->all());
         }
+    }
+
+    public function enableCsrf(bool $strict = true, ?Request $request = null): self
+    {
+        $validator = new SameOriginCsrfValidator($request, $strict);
+        $this->form->setCsrfValidator($validator);
+
+        return $this;
+    }
+
+    public function setCsrfValidator(CsrfValidatorInterface $validator): self
+    {
+        $this->form->setCsrfValidator($validator);
+
+        return $this;
     }
 }

--- a/src/FormRenderer.php
+++ b/src/FormRenderer.php
@@ -115,6 +115,13 @@ class FormRenderer
 
         $this->element->attributes->setData('invalid_element', htmlentities($this->form->createInvalidElement()->render()));
 
+        if ($errorMessage = $this->form->getErrorMessage()) {
+            $error = new Element('div.alert.alert-danger');
+            $error->setInnerText($errorMessage);
+
+            $this->element->addChild($error);
+        }
+
         $this->addFieldsToElement();
 
         $this->built = true;

--- a/tests/unit/Csrf/SameOriginCsrfValidatorTest.php
+++ b/tests/unit/Csrf/SameOriginCsrfValidatorTest.php
@@ -1,0 +1,324 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Palmtree\Form\Test\unit\Csrf;
+
+use Palmtree\Form\Csrf\SameOriginCsrfValidator;
+use Palmtree\Form\Exception\CsrfValidationFailedException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class SameOriginCsrfValidatorTest extends TestCase
+{
+    public function testValidateWithInvalidOriginThrowsException(): void
+    {
+        $request = Request::create('https://example.com', 'POST', [], [], [], [
+            'HTTP_ORIGIN' => 'https://malicious.com',
+        ]);
+
+        $validator = new SameOriginCsrfValidator($request);
+
+        $this->expectException(CsrfValidationFailedException::class);
+        $this->expectExceptionMessage('CSRF validation failed: invalid origin.');
+        $validator->validate();
+    }
+
+    public function testValidateWithValidOrigin(): void
+    {
+        $request = Request::create('https://example.com', 'POST', [], [], [], [
+            'HTTP_ORIGIN' => 'https://example.com',
+            'HTTPS' => 'on',
+        ]);
+
+        $validator = new SameOriginCsrfValidator($request);
+
+        $validator->validate();
+        $this->assertTrue(true); // No exception thrown
+    }
+
+    public function testIsValidOriginWithMatchingOriginHeader(): void
+    {
+        $request = Request::create('https://example.com/path', 'POST', [], [], [], [
+            'HTTP_ORIGIN' => 'https://example.com',
+        ]);
+
+        $validator = new SameOriginCsrfValidator($request);
+        $this->assertTrue($validator->isValidOrigin());
+    }
+
+    public function testIsValidOriginWithMatchingRefererHeader(): void
+    {
+        $request = Request::create('https://example.com/path', 'POST', [], [], [], [
+            'HTTP_REFERER' => 'https://example.com/previous',
+        ]);
+
+        $validator = new SameOriginCsrfValidator($request);
+        $this->assertTrue($validator->isValidOrigin());
+    }
+
+    public function testIsValidOriginWithDifferentOrigin(): void
+    {
+        $request = Request::create('https://example.com', 'POST', [], [], [], [
+            'HTTP_ORIGIN' => 'https://malicious.com',
+        ]);
+
+        $validator = new SameOriginCsrfValidator($request);
+        $this->assertFalse($validator->isValidOrigin());
+    }
+
+    public function testIsValidOriginWithDifferentReferer(): void
+    {
+        $request = Request::create('https://example.com', 'POST', [], [], [], [
+            'HTTP_REFERER' => 'https://malicious.com/page',
+        ]);
+
+        $validator = new SameOriginCsrfValidator($request);
+        $this->assertFalse($validator->isValidOrigin());
+    }
+
+    public function testIsValidOriginWithNoHeaders(): void
+    {
+        $request = Request::create('https://example.com', 'POST');
+
+        $validator = new SameOriginCsrfValidator($request);
+        $this->assertNull($validator->isValidOrigin());
+    }
+
+    public function testIsValidOriginWithNullOrigin(): void
+    {
+        $request = Request::create('https://example.com', 'POST', [], [], [], [
+            'HTTP_ORIGIN' => 'null',
+        ]);
+
+        $validator = new SameOriginCsrfValidator($request);
+        $this->assertNull($validator->isValidOrigin());
+    }
+
+    public function testIsValidOriginPreferOriginOverReferer(): void
+    {
+        $request = Request::create('https://example.com', 'POST', [], [], [], [
+            'HTTP_ORIGIN' => 'https://example.com',
+            'HTTP_REFERER' => 'https://malicious.com',
+        ]);
+
+        $validator = new SameOriginCsrfValidator($request);
+        $this->assertTrue($validator->isValidOrigin());
+    }
+
+    public function testIsValidOriginWithHttpRequest(): void
+    {
+        $request = Request::create('http://example.com', 'POST', [], [], [], [
+            'HTTP_ORIGIN' => 'http://example.com',
+        ]);
+
+        $validator = new SameOriginCsrfValidator($request);
+        $this->assertTrue($validator->isValidOrigin());
+    }
+
+    public function testIsValidOriginWithSecFetchSiteSameOrigin(): void
+    {
+        // Test that Sec-Fetch-Site header is checked and returns true for 'same-origin'
+        $request = Request::create('https://example.com', 'POST', [], [], [], [
+            'HTTP_SEC_FETCH_SITE' => 'same-origin',
+        ]);
+
+        $validator = new SameOriginCsrfValidator($request);
+        $result = $validator->isValidOrigin();
+        $this->assertTrue($result);
+    }
+
+    public function testIsValidOriginWithSecFetchSiteCrossOrigin(): void
+    {
+        // Test that Sec-Fetch-Site header returns false for non-same-origin values
+        $request = Request::create('https://example.com', 'POST', [], [], [], [
+            'HTTP_SEC_FETCH_SITE' => 'cross-site',
+        ]);
+
+        $validator = new SameOriginCsrfValidator($request);
+        $result = $validator->isValidOrigin();
+        $this->assertFalse($result);
+    }
+
+    public function testIsValidOriginWithSecFetchSiteSameSite(): void
+    {
+        // Test that Sec-Fetch-Site header returns false for 'same-site' (not same-origin)
+        $request = Request::create('https://example.com', 'POST', [], [], [], [
+            'HTTP_SEC_FETCH_SITE' => 'same-site',
+        ]);
+
+        $validator = new SameOriginCsrfValidator($request);
+        $result = $validator->isValidOrigin();
+        $this->assertFalse($result);
+    }
+
+    public function testIsValidOriginSecFetchSiteTakesPrecedence(): void
+    {
+        // Test that Sec-Fetch-Site header takes precedence over Origin header
+        $request = Request::create('https://example.com', 'POST', [], [], [], [
+            'HTTP_SEC_FETCH_SITE' => 'same-origin',
+            'HTTP_ORIGIN' => 'https://malicious.com',
+        ]);
+
+        $validator = new SameOriginCsrfValidator($request);
+        $result = $validator->isValidOrigin();
+        // Sec-Fetch-Site is checked first, so it should return true
+        $this->assertTrue($result);
+    }
+
+    public function testValidateWithStrictTrueAndNullOriginThrowsException(): void
+    {
+        // When strict=true (default) and isValidOrigin() returns null, validation should fail
+        $request = Request::create('https://example.com', 'POST');
+
+        $validator = new SameOriginCsrfValidator($request, strict: true);
+
+        $this->expectException(CsrfValidationFailedException::class);
+        $this->expectExceptionMessage('CSRF validation failed: invalid origin.');
+        $validator->validate();
+    }
+
+    public function testValidateWithStrictFalseAndNullOriginPasses(): void
+    {
+        // When strict=false and isValidOrigin() returns null, validation should pass
+        $request = Request::create('https://example.com', 'POST');
+
+        $validator = new SameOriginCsrfValidator($request, strict: false);
+
+        $validator->validate();
+        $this->assertTrue(true); // No exception thrown
+    }
+
+    public function testValidateWithStrictTrueAndNullOriginFromNullHeaderThrowsException(): void
+    {
+        // When strict=true and Origin header is 'null', isValidOrigin() returns null, validation should fail
+        $request = Request::create('https://example.com', 'POST', [], [], [], [
+            'HTTP_ORIGIN' => 'null',
+        ]);
+
+        $validator = new SameOriginCsrfValidator($request, strict: true);
+
+        $this->expectException(CsrfValidationFailedException::class);
+        $this->expectExceptionMessage('CSRF validation failed: invalid origin.');
+        $validator->validate();
+    }
+
+    public function testValidateWithStrictFalseAndNullOriginFromNullHeaderPasses(): void
+    {
+        // When strict=false and Origin header is 'null', isValidOrigin() returns null, validation should pass
+        $request = Request::create('https://example.com', 'POST', [], [], [], [
+            'HTTP_ORIGIN' => 'null',
+        ]);
+
+        $validator = new SameOriginCsrfValidator($request, strict: false);
+
+        $validator->validate();
+        $this->assertTrue(true); // No exception thrown
+    }
+
+    public function testValidateWithTrustedHostsAndValidOrigin(): void
+    {
+        // Test that validation works correctly with trusted hosts set
+        $request = Request::create('https://example.com', 'POST', [], [], [], [
+            'HTTP_ORIGIN' => 'https://example.com',
+        ]);
+
+        Request::setTrustedHosts(['example.com']);
+
+        $validator = new SameOriginCsrfValidator($request);
+
+        $validator->validate();
+        $this->assertTrue(true); // No exception thrown
+    }
+
+    public function testValidateWithTrustedHostsAndInvalidOrigin(): void
+    {
+        // Test that validation fails with untrusted origin even with trusted hosts set
+        $request = Request::create('https://example.com', 'POST', [], [], [], [
+            'HTTP_ORIGIN' => 'https://untrusted.com',
+        ]);
+
+        Request::setTrustedHosts(['example.com']);
+
+        $validator = new SameOriginCsrfValidator($request);
+
+        $this->expectException(CsrfValidationFailedException::class);
+        $validator->validate();
+    }
+
+    public function testValidateWithMultipleTrustedHostsAndValidOrigin(): void
+    {
+        // Test with multiple trusted hosts
+        $request = Request::create('https://api.example.com', 'POST', [], [], [], [
+            'HTTP_ORIGIN' => 'https://api.example.com',
+        ]);
+
+        Request::setTrustedHosts(['example.com', 'api.example.com', 'cdn.example.com']);
+
+        $validator = new SameOriginCsrfValidator($request);
+
+        $validator->validate();
+        $this->assertTrue(true); // No exception thrown
+    }
+
+    public function testValidateWithTrustedHostsWildcardAndValidOrigin(): void
+    {
+        // Test with wildcard pattern in trusted hosts
+        $request = Request::create('https://sub.example.com', 'POST', [], [], [], [
+            'HTTP_ORIGIN' => 'https://sub.example.com',
+        ]);
+
+        Request::setTrustedHosts(['.example.com']);
+
+        $validator = new SameOriginCsrfValidator($request);
+
+        $validator->validate();
+        $this->assertTrue(true); // No exception thrown
+    }
+
+    public function testValidateWithTrustedHostsAndRefererHeader(): void
+    {
+        // Test validation with Referer header when trusted hosts are set
+        $request = Request::create('https://example.com/form', 'POST', [], [], [], [
+            'HTTP_REFERER' => 'https://example.com/page',
+        ]);
+
+        Request::setTrustedHosts(['example.com']);
+
+        $validator = new SameOriginCsrfValidator($request);
+
+        $validator->validate();
+        $this->assertTrue(true); // No exception thrown
+    }
+
+    public function testValidateWithTrustedHostsAndInvalidReferer(): void
+    {
+        // Test validation fails with invalid Referer even with trusted hosts set
+        $request = Request::create('https://example.com/form', 'POST', [], [], [], [
+            'HTTP_REFERER' => 'https://malicious.com/attack',
+        ]);
+
+        Request::setTrustedHosts(['example.com']);
+
+        $validator = new SameOriginCsrfValidator($request);
+
+        $this->expectException(CsrfValidationFailedException::class);
+        $validator->validate();
+    }
+
+    public function testValidateWithRequestHostNotInTrustedHosts(): void
+    {
+        // Test that validation fails when the request host itself is not in trusted hosts
+        $request = Request::create('https://untrusted.com/form', 'POST', [], [], [], [
+            'HTTP_ORIGIN' => 'https://untrusted.com',
+        ]);
+
+        Request::setTrustedHosts(['example.com', 'api.example.com']);
+
+        $validator = new SameOriginCsrfValidator($request);
+
+        $this->expectException(CsrfValidationFailedException::class);
+        $this->expectExceptionMessage('Untrusted Host "untrusted.com"');
+        $validator->validate();
+    }
+}


### PR DESCRIPTION
Implement modern CSRF protection using Sec-Fetch-Site, falling back to Origin and Referer headers.

Thanks to https://words.filippo.io/csrf/